### PR TITLE
Add dreammaker.returnDreamDaemonPath command

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"onCommand:dreammaker.toggleTicked",
 		"onCommand:dreammaker.openReference",
 		"onCommand:dreammaker.findReferencesTree",
+		"onCommand:dreammaker.returnDreamdaemonPath",
 		"onDebugResolve:byond"
 	],
 	"main": "./dist/extension",
@@ -63,6 +64,11 @@
 			{
 				"command": "dreammaker.findReferencesTree",
 				"title": "Find All References (Object Tree)",
+				"category": "DreamMaker"
+			},
+			{
+				"command": "dreammaker.returnDreamdaemonPath",
+				"title": "Return Dreamdaemon Path",
 				"category": "DreamMaker"
 			}
 		],
@@ -244,6 +250,7 @@
 	"dependencies": {
 		"mkdirp": "^1.0.4",
 		"node-fetch": "^2.6.1",
+		"vsce": "^1.83.0",
 		"vscode-languageclient": "^5.2.1"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -65,11 +65,6 @@
 				"command": "dreammaker.findReferencesTree",
 				"title": "Find All References (Object Tree)",
 				"category": "DreamMaker"
-			},
-			{
-				"command": "dreammaker.returnDreamdaemonPath",
-				"title": "Return Dreamdaemon Path",
-				"category": "DreamMaker"
 			}
 		],
 		"keybindings": [
@@ -250,7 +245,6 @@
 	"dependencies": {
 		"mkdirp": "^1.0.4",
 		"node-fetch": "^2.6.1",
-		"vsce": "^1.83.0",
 		"vscode-languageclient": "^5.2.1"
 	},
 	"devDependencies": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,6 +82,10 @@ export async function activate(context: ExtensionContext) {
 		return environment_file && environment_file.replace(/\.dme$/, ".dmb");
 	}));
 
+	context.subscriptions.push(commands.registerCommand('dreammaker.returnDreamdaemonPath', async () => {
+		return config.find_byond_file(['bin/dreamdaemon.exe'])
+	}));
+
 	// register the docs provider
 	docs_provider = new reference.Provider();
 	context.subscriptions.push(workspace.registerTextDocumentContentProvider(docs_provider.scheme, docs_provider));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,7 +82,7 @@ export async function activate(context: ExtensionContext) {
 		return environment_file && environment_file.replace(/\.dme$/, ".dmb");
 	}));
 
-	context.subscriptions.push(commands.registerCommand('dreammaker.returnDreamdaemonPath', async () => {
+	context.subscriptions.push(commands.registerCommand('dreammaker.returnDreamDaemonPath', async () => {
 		return config.find_byond_file(['bin/dreamdaemon.exe'])
 	}));
 


### PR DESCRIPTION
For use with tasks that want to run it with additional arguments and/or without attaching the debugger.

Example usage:
```json
{
	"type": "shell",
	"command": "${command:dreammaker.returnDreamDaemonPath}",
	"args": [
		"${command:dreammaker.getFilenameDmb}",
		"-trusted",
		"-once",
		"-close"
	],
	"label": "run"
},
```

Could alternatively return all instead of one so you could use it in ${input:} task prompts.