### PR TITLE
Some routine package updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Additional extension features include:
 1. Install [Node and NPM][node].
 2. Download dependencies: `npm install`
 3. If installing VSCE globally:
-   1. `sudo npm install -g vsce`
+   1. `sudo npm install -g @vscode/vsce`
    2. `vsce package`
 4. If installing VSCE locally:
-   1. `npm install vsce`
+   1. `npm install @vscode/vsce`
    2. `./node_modules/vsce/out/vsce package`
 5. Install produced `.vsix` into Visual Studio Code.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,21 +9,21 @@
 			"version": "0.2.2",
 			"license": "GPL-3.0",
 			"dependencies": {
-				"mkdirp": "^1.0.4",
-				"node-fetch": "^3.2.10",
-				"vscode-languageclient": "^5.2.1"
+				"mkdirp": "^3.0.1",
+				"node-fetch": "^3.3.2",
+				"vscode-languageclient": "^6.1.4"
 			},
 			"devDependencies": {
-				"@types/mkdirp": "^1.0.2",
-				"@types/node": "^7.10.14",
-				"@types/node-fetch": "^1.6.9",
+				"@types/mkdirp": "^2.0.0",
+				"@types/node": "^20.11.0",
+				"@types/node-fetch": "^2.6.10",
 				"@types/vscode": "^1.30.0",
-				"@types/webpack": "^4.41.32",
-				"ts-loader": "^9.4.2",
-				"tslint": "^5.20.1",
-				"typescript": "^3.9.10",
-				"webpack": "^5.76.0",
-				"webpack-cli": "^4.9.1"
+				"@types/webpack": "^5.28.5",
+				"ts-loader": "^9.5.1",
+				"tslint": "^6.1.3",
+				"typescript": "^5.3.3",
+				"webpack": "^5.89.0",
+				"webpack-cli": "^5.1.4"
 			},
 			"engines": {
 				"vscode": "^1.30.0"
@@ -137,9 +137,9 @@
 			}
 		},
 		"node_modules/@types/estree": {
-			"version": "0.0.51",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-			"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
 			"dev": true
 		},
 		"node_modules/@types/json-schema": {
@@ -149,265 +149,234 @@
 			"dev": true
 		},
 		"node_modules/@types/mkdirp": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.2.tgz",
-			"integrity": "sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-2.0.0.tgz",
+			"integrity": "sha512-c/iUqMymAlxLAyIK3u5SzrwkrkyOdv1XDc91T+b5FsY7Jr6ERhUD19jJHOhPW4GD6tmN6mFEorfSdks525pwdQ==",
+			"deprecated": "This is a stub types definition. mkdirp provides its own type definitions, so you do not need this installed.",
 			"dev": true,
 			"dependencies": {
-				"@types/node": "*"
+				"mkdirp": "*"
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "7.10.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.14.tgz",
-			"integrity": "sha512-29GS75BE8asnTno3yB6ubOJOO0FboExEqNJy4bpz0GSmW/8wPTNL4h9h63c6s1uTrOopCmJYe/4yJLh5r92ZUA==",
-			"dev": true
-		},
-		"node_modules/@types/node-fetch": {
-			"version": "1.6.9",
-			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-1.6.9.tgz",
-			"integrity": "sha512-n2r6WLoY7+uuPT7pnEtKJCmPUGyJ+cbyBR8Avnu4+m1nzz7DwBVuyIvvlBzCZ/nrpC7rIgb3D6pNavL7rFEa9g==",
+			"version": "20.11.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.0.tgz",
+			"integrity": "sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==",
 			"dev": true,
 			"dependencies": {
-				"@types/node": "*"
+				"undici-types": "~5.26.4"
 			}
 		},
-		"node_modules/@types/source-list-map": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
-			"integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
-			"dev": true
-		},
-		"node_modules/@types/tapable": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
-			"integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
-			"dev": true
-		},
-		"node_modules/@types/uglify-js": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.13.1.tgz",
-			"integrity": "sha512-O3MmRAk6ZuAKa9CHgg0Pr0+lUOqoMLpc9AS4R8ano2auvsg7IE8syF3Xh/NPr26TWklxYcqoEEFdzLLs1fV9PQ==",
+		"node_modules/@types/node-fetch": {
+			"version": "2.6.10",
+			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.10.tgz",
+			"integrity": "sha512-PPpPK6F9ALFTn59Ka3BaL+qGuipRfxNE8qVgkp0bVixeiR2c2/L+IVOiBdu9JhhT22sWnQEp6YyHGI2b2+CMcA==",
 			"dev": true,
 			"dependencies": {
-				"source-map": "^0.6.1"
+				"@types/node": "*",
+				"form-data": "^4.0.0"
 			}
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.62.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
-			"integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA==",
+			"version": "1.85.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.85.0.tgz",
+			"integrity": "sha512-CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==",
 			"dev": true
 		},
 		"node_modules/@types/webpack": {
-			"version": "4.41.32",
-			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.32.tgz",
-			"integrity": "sha512-cb+0ioil/7oz5//7tZUSwbrSAN/NWHrQylz5cW8G0dWTcF/g+/dSdMlKVZspBYuMAN1+WnwHrkxiRrLcwd0Heg==",
+			"version": "5.28.5",
+			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-5.28.5.tgz",
+			"integrity": "sha512-wR87cgvxj3p6D0Crt1r5avwqffqPXUkNlnQ1mjU93G7gCuFjufZR4I6j8cz5g1F1tTYpfOOFvly+cmIQwL9wvw==",
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*",
-				"@types/tapable": "^1",
-				"@types/uglify-js": "*",
-				"@types/webpack-sources": "*",
-				"anymatch": "^3.0.0",
-				"source-map": "^0.6.0"
-			}
-		},
-		"node_modules/@types/webpack-sources": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-3.2.0.tgz",
-			"integrity": "sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*",
-				"@types/source-list-map": "*",
-				"source-map": "^0.7.3"
-			}
-		},
-		"node_modules/@types/webpack-sources/node_modules/source-map": {
-			"version": "0.7.3",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-			"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-			"dev": true,
-			"engines": {
-				"node": ">= 8"
+				"tapable": "^2.2.0",
+				"webpack": "^5"
 			}
 		},
 		"node_modules/@webassemblyjs/ast": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
-			"integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.6.tgz",
+			"integrity": "sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==",
 			"dev": true,
 			"dependencies": {
-				"@webassemblyjs/helper-numbers": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+				"@webassemblyjs/helper-numbers": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6"
 			}
 		},
 		"node_modules/@webassemblyjs/floating-point-hex-parser": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-			"integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
+			"integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
 			"dev": true
 		},
 		"node_modules/@webassemblyjs/helper-api-error": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-			"integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
+			"integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
 			"dev": true
 		},
 		"node_modules/@webassemblyjs/helper-buffer": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-			"integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.6.tgz",
+			"integrity": "sha512-z3nFzdcp1mb8nEOFFk8DrYLpHvhKC3grJD2ardfKOzmbmJvEf/tPIqCY+sNcwZIY8ZD7IkB2l7/pqhUhqm7hLA==",
 			"dev": true
 		},
 		"node_modules/@webassemblyjs/helper-numbers": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
-			"integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
+			"integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
 			"dev": true,
 			"dependencies": {
-				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
-				"@webassemblyjs/helper-api-error": "1.11.1",
+				"@webassemblyjs/floating-point-hex-parser": "1.11.6",
+				"@webassemblyjs/helper-api-error": "1.11.6",
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"node_modules/@webassemblyjs/helper-wasm-bytecode": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-			"integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
+			"integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
 			"dev": true
 		},
 		"node_modules/@webassemblyjs/helper-wasm-section": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
-			"integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.6.tgz",
+			"integrity": "sha512-LPpZbSOwTpEC2cgn4hTydySy1Ke+XEu+ETXuoyvuyezHO3Kjdu90KK95Sh9xTbmjrCsUwvWwCOQQNta37VrS9g==",
 			"dev": true,
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1"
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-buffer": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/wasm-gen": "1.11.6"
 			}
 		},
 		"node_modules/@webassemblyjs/ieee754": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
-			"integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
+			"integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
 			"dev": true,
 			"dependencies": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
 		},
 		"node_modules/@webassemblyjs/leb128": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
-			"integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
+			"integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
 			"dev": true,
 			"dependencies": {
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"node_modules/@webassemblyjs/utf8": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-			"integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
+			"integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
 			"dev": true
 		},
 		"node_modules/@webassemblyjs/wasm-edit": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
-			"integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.6.tgz",
+			"integrity": "sha512-Ybn2I6fnfIGuCR+Faaz7YcvtBKxvoLV3Lebn1tM4o/IAJzmi9AWYIPWpyBfU8cC+JxAO57bk4+zdsTjJR+VTOw==",
 			"dev": true,
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/helper-wasm-section": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1",
-				"@webassemblyjs/wasm-opt": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1",
-				"@webassemblyjs/wast-printer": "1.11.1"
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-buffer": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/helper-wasm-section": "1.11.6",
+				"@webassemblyjs/wasm-gen": "1.11.6",
+				"@webassemblyjs/wasm-opt": "1.11.6",
+				"@webassemblyjs/wasm-parser": "1.11.6",
+				"@webassemblyjs/wast-printer": "1.11.6"
 			}
 		},
 		"node_modules/@webassemblyjs/wasm-gen": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
-			"integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.6.tgz",
+			"integrity": "sha512-3XOqkZP/y6B4F0PBAXvI1/bky7GryoogUtfwExeP/v7Nzwo1QLcq5oQmpKlftZLbT+ERUOAZVQjuNVak6UXjPA==",
 			"dev": true,
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/ieee754": "1.11.1",
-				"@webassemblyjs/leb128": "1.11.1",
-				"@webassemblyjs/utf8": "1.11.1"
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/ieee754": "1.11.6",
+				"@webassemblyjs/leb128": "1.11.6",
+				"@webassemblyjs/utf8": "1.11.6"
 			}
 		},
 		"node_modules/@webassemblyjs/wasm-opt": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
-			"integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.6.tgz",
+			"integrity": "sha512-cOrKuLRE7PCe6AsOVl7WasYf3wbSo4CeOk6PkrjS7g57MFfVUF9u6ysQBBODX0LdgSvQqRiGz3CXvIDKcPNy4g==",
 			"dev": true,
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1"
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-buffer": "1.11.6",
+				"@webassemblyjs/wasm-gen": "1.11.6",
+				"@webassemblyjs/wasm-parser": "1.11.6"
 			}
 		},
 		"node_modules/@webassemblyjs/wasm-parser": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
-			"integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.6.tgz",
+			"integrity": "sha512-6ZwPeGzMJM3Dqp3hCsLgESxBGtT/OeCvCZ4TA1JUPYgmhAx38tTPR9JaKy0S5H3evQpO/h2uWs2j6Yc/fjkpTQ==",
 			"dev": true,
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-api-error": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/ieee754": "1.11.1",
-				"@webassemblyjs/leb128": "1.11.1",
-				"@webassemblyjs/utf8": "1.11.1"
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-api-error": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/ieee754": "1.11.6",
+				"@webassemblyjs/leb128": "1.11.6",
+				"@webassemblyjs/utf8": "1.11.6"
 			}
 		},
 		"node_modules/@webassemblyjs/wast-printer": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
-			"integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.6.tgz",
+			"integrity": "sha512-JM7AhRcE+yW2GWYaKeHL5vt4xqee5N2WcezptmgyhNS+ScggqcT1OtXykhAb13Sn5Yas0j2uv9tHgrjwvzAP4A==",
 			"dev": true,
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
+				"@webassemblyjs/ast": "1.11.6",
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"node_modules/@webpack-cli/configtest": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
-			"integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
+			"integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
 			"dev": true,
+			"engines": {
+				"node": ">=14.15.0"
+			},
 			"peerDependencies": {
-				"webpack": "4.x.x || 5.x.x",
-				"webpack-cli": "4.x.x"
+				"webpack": "5.x.x",
+				"webpack-cli": "5.x.x"
 			}
 		},
 		"node_modules/@webpack-cli/info": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
-			"integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
+			"integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
 			"dev": true,
-			"dependencies": {
-				"envinfo": "^7.7.3"
+			"engines": {
+				"node": ">=14.15.0"
 			},
 			"peerDependencies": {
-				"webpack-cli": "4.x.x"
+				"webpack": "5.x.x",
+				"webpack-cli": "5.x.x"
 			}
 		},
 		"node_modules/@webpack-cli/serve": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
-			"integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
+			"integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
 			"dev": true,
+			"engines": {
+				"node": ">=14.15.0"
+			},
 			"peerDependencies": {
-				"webpack-cli": "4.x.x"
+				"webpack": "5.x.x",
+				"webpack-cli": "5.x.x"
 			},
 			"peerDependenciesMeta": {
 				"webpack-dev-server": {
@@ -440,9 +409,9 @@
 			}
 		},
 		"node_modules/acorn-import-assertions": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+			"integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
 			"dev": true,
 			"peerDependencies": {
 				"acorn": "^8"
@@ -485,19 +454,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/anymatch": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-			"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-			"dev": true,
-			"dependencies": {
-				"normalize-path": "^3.0.0",
-				"picomatch": "^2.0.4"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -506,6 +462,12 @@
 			"dependencies": {
 				"sprintf-js": "~1.0.2"
 			}
+		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+			"dev": true
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.0",
@@ -652,6 +614,18 @@
 			"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
 			"dev": true
 		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -686,6 +660,15 @@
 				"node": ">= 12"
 			}
 		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/diff": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
@@ -702,9 +685,9 @@
 			"dev": true
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
-			"integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
+			"version": "5.15.0",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
+			"integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
 			"dev": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
@@ -715,9 +698,9 @@
 			}
 		},
 		"node_modules/envinfo": {
-			"version": "7.8.1",
-			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
-			"integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.11.0.tgz",
+			"integrity": "sha512-G9/6xF1FPbIw0TtalAMaVPpiq2aDEuKLXM314jPVAO9r2fo2a4BLqMNkmRS7O/xPPZ+COAhGIz3ETvHEV3eUcg==",
 			"dev": true,
 			"bin": {
 				"envinfo": "dist/cli.js"
@@ -727,9 +710,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "0.9.3",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
+			"integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==",
 			"dev": true
 		},
 		"node_modules/escalade": {
@@ -824,29 +807,6 @@
 				"node": ">=0.8.x"
 			}
 		},
-		"node_modules/execa": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-			"dev": true,
-			"dependencies": {
-				"cross-spawn": "^7.0.3",
-				"get-stream": "^6.0.0",
-				"human-signals": "^2.1.0",
-				"is-stream": "^2.0.0",
-				"merge-stream": "^2.0.0",
-				"npm-run-path": "^4.0.1",
-				"onetime": "^5.1.2",
-				"signal-exit": "^3.0.3",
-				"strip-final-newline": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/execa?sponsor=1"
-			}
-		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -912,6 +872,20 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/form-data": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"dev": true,
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/formdata-polyfill": {
 			"version": "4.0.10",
 			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -929,16 +903,13 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
 		},
-		"node_modules/get-stream": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
 			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
 			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/glob": {
@@ -982,13 +953,16 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/human-signals": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+		"node_modules/hasown": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+			"integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
 			"dev": true,
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
 			"engines": {
-				"node": ">=10.17.0"
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/import-local": {
@@ -1024,12 +998,24 @@
 			"dev": true
 		},
 		"node_modules/interpret": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-			"integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+			"integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
 			"dev": true,
 			"engines": {
-				"node": ">= 0.10"
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/is-core-module": {
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+			"integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+			"dev": true,
+			"dependencies": {
+				"hasown": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-number": {
@@ -1053,22 +1039,10 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-stream": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
 		},
 		"node_modules/isobject": {
@@ -1243,15 +1217,6 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/mimic-fn": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -1271,14 +1236,17 @@
 			"dev": true
 		},
 		"node_modules/mkdirp": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+			"integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
 			"bin": {
-				"mkdirp": "bin/cmd.js"
+				"mkdirp": "dist/cjs/src/bin.js"
 			},
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/neo-async": {
@@ -1306,9 +1274,9 @@
 			}
 		},
 		"node_modules/node-fetch": {
-			"version": "3.2.10",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
-			"integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
 			"dependencies": {
 				"data-uri-to-buffer": "^4.0.0",
 				"fetch-blob": "^3.1.4",
@@ -1328,27 +1296,6 @@
 			"integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
 			"dev": true
 		},
-		"node_modules/normalize-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/npm-run-path": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-			"dev": true,
-			"dependencies": {
-				"path-key": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1356,21 +1303,6 @@
 			"dev": true,
 			"dependencies": {
 				"wrappy": "1"
-			}
-		},
-		"node_modules/onetime": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-			"dev": true,
-			"dependencies": {
-				"mimic-fn": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-limit": {
@@ -1448,18 +1380,6 @@
 			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
 			"dev": true
 		},
-		"node_modules/picomatch": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/pkg-dir": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -1491,24 +1411,32 @@
 			}
 		},
 		"node_modules/rechoir": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
-			"integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+			"integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
 			"dev": true,
 			"dependencies": {
-				"resolve": "^1.9.0"
+				"resolve": "^1.20.0"
 			},
 			"engines": {
-				"node": ">= 0.10"
+				"node": ">= 10.13.0"
 			}
 		},
 		"node_modules/resolve": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-			"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+			"version": "1.22.8",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
 			"dev": true,
 			"dependencies": {
-				"path-parse": "^1.0.6"
+				"is-core-module": "^2.13.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/resolve-cwd": {
@@ -1553,9 +1481,9 @@
 			]
 		},
 		"node_modules/schema-utils": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-			"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+			"integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
 			"dev": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.8",
@@ -1574,6 +1502,7 @@
 			"version": "5.7.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
 			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"dev": true,
 			"bin": {
 				"semver": "bin/semver"
 			}
@@ -1620,12 +1549,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/signal-exit": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
-			"integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
-			"dev": true
-		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -1651,15 +1574,6 @@
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},
-		"node_modules/strip-final-newline": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -1670,6 +1584,18 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/tapable": {
@@ -1746,15 +1672,16 @@
 			}
 		},
 		"node_modules/ts-loader": {
-			"version": "9.4.2",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.4.2.tgz",
-			"integrity": "sha512-OmlC4WVmFv5I0PpaxYb+qGeGOdm5giHU7HwDDUjw59emP2UYMHy9fFSDcYgSNoH8sXcj4hGCSEhlDZ9ULeDraA==",
+			"version": "9.5.1",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.1.tgz",
+			"integrity": "sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.1.0",
 				"enhanced-resolve": "^5.0.0",
 				"micromatch": "^4.0.0",
-				"semver": "^7.3.4"
+				"semver": "^7.3.4",
+				"source-map": "^0.7.4"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -1837,6 +1764,15 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/ts-loader/node_modules/source-map": {
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+			"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/ts-loader/node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -1850,15 +1786,16 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true
 		},
 		"node_modules/tslint": {
-			"version": "5.20.1",
-			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-			"integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
+			"integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
+			"deprecated": "TSLint has been deprecated in favor of ESLint. Please see https://github.com/palantir/tslint/issues/4534 for more information.",
 			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.0.0",
@@ -1869,10 +1806,10 @@
 				"glob": "^7.1.1",
 				"js-yaml": "^3.13.1",
 				"minimatch": "^3.0.4",
-				"mkdirp": "^0.5.1",
+				"mkdirp": "^0.5.3",
 				"resolve": "^1.3.2",
 				"semver": "^5.3.0",
-				"tslib": "^1.8.0",
+				"tslib": "^1.13.0",
 				"tsutils": "^2.29.0"
 			},
 			"bin": {
@@ -1882,7 +1819,7 @@
 				"node": ">=4.8.0"
 			},
 			"peerDependencies": {
-				"typescript": ">=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev"
+				"typescript": ">=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 4.0.0-dev"
 			}
 		},
 		"node_modules/tslint/node_modules/mkdirp": {
@@ -1910,17 +1847,23 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "3.9.10",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true
 		},
 		"node_modules/update-browserslist-db": {
 			"version": "1.0.10",
@@ -1958,38 +1901,46 @@
 			}
 		},
 		"node_modules/vscode-jsonrpc": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-			"integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
+			"integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==",
 			"engines": {
 				"node": ">=8.0.0 || >=10.0.0"
 			}
 		},
 		"node_modules/vscode-languageclient": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-5.2.1.tgz",
-			"integrity": "sha512-7jrS/9WnV0ruqPamN1nE7qCxn0phkH5LjSgSp9h6qoJGoeAKzwKz/PF6M+iGA/aklx4GLZg1prddhEPQtuXI1Q==",
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-6.1.4.tgz",
+			"integrity": "sha512-EUOU+bJu6axmt0RFNo3nrglQLPXMfanbYViJee3Fbn2VuQoX0ZOI4uTYhSRvYLP2vfwTP/juV62P/mksCdTZMA==",
 			"dependencies": {
-				"semver": "^5.5.0",
-				"vscode-languageserver-protocol": "3.14.1"
+				"semver": "^6.3.0",
+				"vscode-languageserver-protocol": "3.15.3"
 			},
 			"engines": {
-				"vscode": "^1.30"
+				"vscode": "^1.41.0"
+			}
+		},
+		"node_modules/vscode-languageclient/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"bin": {
+				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/vscode-languageserver-protocol": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz",
-			"integrity": "sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==",
+			"version": "3.15.3",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz",
+			"integrity": "sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==",
 			"dependencies": {
-				"vscode-jsonrpc": "^4.0.0",
-				"vscode-languageserver-types": "3.14.0"
+				"vscode-jsonrpc": "^5.0.1",
+				"vscode-languageserver-types": "3.15.1"
 			}
 		},
 		"node_modules/vscode-languageserver-types": {
-			"version": "3.14.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
-			"integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A=="
+			"version": "3.15.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
+			"integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
 		},
 		"node_modules/watchpack": {
 			"version": "2.4.0",
@@ -2013,22 +1964,22 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.76.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.0.tgz",
-			"integrity": "sha512-l5sOdYBDunyf72HW8dF23rFtWq/7Zgvt/9ftMof71E/yUb1YLOBmTgA2K4vQthB3kotMrSj609txVE0dnr2fjA==",
+			"version": "5.89.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
+			"integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
 			"dev": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.3",
-				"@types/estree": "^0.0.51",
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/wasm-edit": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1",
+				"@types/estree": "^1.0.0",
+				"@webassemblyjs/ast": "^1.11.5",
+				"@webassemblyjs/wasm-edit": "^1.11.5",
+				"@webassemblyjs/wasm-parser": "^1.11.5",
 				"acorn": "^8.7.1",
-				"acorn-import-assertions": "^1.7.6",
+				"acorn-import-assertions": "^1.9.0",
 				"browserslist": "^4.14.5",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.10.0",
-				"es-module-lexer": "^0.9.0",
+				"enhanced-resolve": "^5.15.0",
+				"es-module-lexer": "^1.2.1",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
@@ -2037,9 +1988,9 @@
 				"loader-runner": "^4.2.0",
 				"mime-types": "^2.1.27",
 				"neo-async": "^2.6.2",
-				"schema-utils": "^3.1.0",
+				"schema-utils": "^3.2.0",
 				"tapable": "^2.1.1",
-				"terser-webpack-plugin": "^5.1.3",
+				"terser-webpack-plugin": "^5.3.7",
 				"watchpack": "^2.4.0",
 				"webpack-sources": "^3.2.3"
 			},
@@ -2060,38 +2011,40 @@
 			}
 		},
 		"node_modules/webpack-cli": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
-			"integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
+			"integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
 			"dev": true,
 			"dependencies": {
 				"@discoveryjs/json-ext": "^0.5.0",
-				"@webpack-cli/configtest": "^1.1.0",
-				"@webpack-cli/info": "^1.4.0",
-				"@webpack-cli/serve": "^1.6.0",
+				"@webpack-cli/configtest": "^2.1.1",
+				"@webpack-cli/info": "^2.0.2",
+				"@webpack-cli/serve": "^2.0.5",
 				"colorette": "^2.0.14",
-				"commander": "^7.0.0",
-				"execa": "^5.0.0",
+				"commander": "^10.0.1",
+				"cross-spawn": "^7.0.3",
+				"envinfo": "^7.7.3",
 				"fastest-levenshtein": "^1.0.12",
 				"import-local": "^3.0.2",
-				"interpret": "^2.2.0",
-				"rechoir": "^0.7.0",
+				"interpret": "^3.1.1",
+				"rechoir": "^0.8.0",
 				"webpack-merge": "^5.7.3"
 			},
 			"bin": {
 				"webpack-cli": "bin/cli.js"
 			},
 			"engines": {
-				"node": ">=10.13.0"
+				"node": ">=14.15.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "4.x.x || 5.x.x"
+				"webpack": "5.x.x"
 			},
 			"peerDependenciesMeta": {
 				"@webpack-cli/generators": {
-					"optional": true
-				},
-				"@webpack-cli/migrate": {
 					"optional": true
 				},
 				"webpack-bundle-analyzer": {
@@ -2103,12 +2056,12 @@
 			}
 		},
 		"node_modules/webpack-cli/node_modules/commander": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+			"integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
 			"dev": true,
 			"engines": {
-				"node": ">= 10"
+				"node": ">=14"
 			}
 		},
 		"node_modules/webpack-merge": {
@@ -2264,9 +2217,9 @@
 			}
 		},
 		"@types/estree": {
-			"version": "0.0.51",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-			"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
 			"dev": true
 		},
 		"@types/json-schema": {
@@ -2276,255 +2229,214 @@
 			"dev": true
 		},
 		"@types/mkdirp": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.2.tgz",
-			"integrity": "sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-2.0.0.tgz",
+			"integrity": "sha512-c/iUqMymAlxLAyIK3u5SzrwkrkyOdv1XDc91T+b5FsY7Jr6ERhUD19jJHOhPW4GD6tmN6mFEorfSdks525pwdQ==",
 			"dev": true,
 			"requires": {
-				"@types/node": "*"
+				"mkdirp": "*"
 			}
 		},
 		"@types/node": {
-			"version": "7.10.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.14.tgz",
-			"integrity": "sha512-29GS75BE8asnTno3yB6ubOJOO0FboExEqNJy4bpz0GSmW/8wPTNL4h9h63c6s1uTrOopCmJYe/4yJLh5r92ZUA==",
-			"dev": true
-		},
-		"@types/node-fetch": {
-			"version": "1.6.9",
-			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-1.6.9.tgz",
-			"integrity": "sha512-n2r6WLoY7+uuPT7pnEtKJCmPUGyJ+cbyBR8Avnu4+m1nzz7DwBVuyIvvlBzCZ/nrpC7rIgb3D6pNavL7rFEa9g==",
+			"version": "20.11.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.0.tgz",
+			"integrity": "sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==",
 			"dev": true,
 			"requires": {
-				"@types/node": "*"
+				"undici-types": "~5.26.4"
 			}
 		},
-		"@types/source-list-map": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
-			"integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
-			"dev": true
-		},
-		"@types/tapable": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
-			"integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
-			"dev": true
-		},
-		"@types/uglify-js": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.13.1.tgz",
-			"integrity": "sha512-O3MmRAk6ZuAKa9CHgg0Pr0+lUOqoMLpc9AS4R8ano2auvsg7IE8syF3Xh/NPr26TWklxYcqoEEFdzLLs1fV9PQ==",
+		"@types/node-fetch": {
+			"version": "2.6.10",
+			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.10.tgz",
+			"integrity": "sha512-PPpPK6F9ALFTn59Ka3BaL+qGuipRfxNE8qVgkp0bVixeiR2c2/L+IVOiBdu9JhhT22sWnQEp6YyHGI2b2+CMcA==",
 			"dev": true,
 			"requires": {
-				"source-map": "^0.6.1"
+				"@types/node": "*",
+				"form-data": "^4.0.0"
 			}
 		},
 		"@types/vscode": {
-			"version": "1.62.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
-			"integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA==",
+			"version": "1.85.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.85.0.tgz",
+			"integrity": "sha512-CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==",
 			"dev": true
 		},
 		"@types/webpack": {
-			"version": "4.41.32",
-			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.32.tgz",
-			"integrity": "sha512-cb+0ioil/7oz5//7tZUSwbrSAN/NWHrQylz5cW8G0dWTcF/g+/dSdMlKVZspBYuMAN1+WnwHrkxiRrLcwd0Heg==",
+			"version": "5.28.5",
+			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-5.28.5.tgz",
+			"integrity": "sha512-wR87cgvxj3p6D0Crt1r5avwqffqPXUkNlnQ1mjU93G7gCuFjufZR4I6j8cz5g1F1tTYpfOOFvly+cmIQwL9wvw==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
-				"@types/tapable": "^1",
-				"@types/uglify-js": "*",
-				"@types/webpack-sources": "*",
-				"anymatch": "^3.0.0",
-				"source-map": "^0.6.0"
-			}
-		},
-		"@types/webpack-sources": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-3.2.0.tgz",
-			"integrity": "sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*",
-				"@types/source-list-map": "*",
-				"source-map": "^0.7.3"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.7.3",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-					"dev": true
-				}
+				"tapable": "^2.2.0",
+				"webpack": "^5"
 			}
 		},
 		"@webassemblyjs/ast": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
-			"integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.6.tgz",
+			"integrity": "sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/helper-numbers": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+				"@webassemblyjs/helper-numbers": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6"
 			}
 		},
 		"@webassemblyjs/floating-point-hex-parser": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-			"integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
+			"integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-api-error": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-			"integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
+			"integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-buffer": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-			"integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.6.tgz",
+			"integrity": "sha512-z3nFzdcp1mb8nEOFFk8DrYLpHvhKC3grJD2ardfKOzmbmJvEf/tPIqCY+sNcwZIY8ZD7IkB2l7/pqhUhqm7hLA==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-numbers": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
-			"integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
+			"integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
-				"@webassemblyjs/helper-api-error": "1.11.1",
+				"@webassemblyjs/floating-point-hex-parser": "1.11.6",
+				"@webassemblyjs/helper-api-error": "1.11.6",
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/helper-wasm-bytecode": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-			"integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
+			"integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-wasm-section": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
-			"integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.6.tgz",
+			"integrity": "sha512-LPpZbSOwTpEC2cgn4hTydySy1Ke+XEu+ETXuoyvuyezHO3Kjdu90KK95Sh9xTbmjrCsUwvWwCOQQNta37VrS9g==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1"
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-buffer": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/wasm-gen": "1.11.6"
 			}
 		},
 		"@webassemblyjs/ieee754": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
-			"integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
+			"integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
 			"dev": true,
 			"requires": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
 		},
 		"@webassemblyjs/leb128": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
-			"integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
+			"integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
 			"dev": true,
 			"requires": {
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/utf8": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-			"integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
+			"integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
 			"dev": true
 		},
 		"@webassemblyjs/wasm-edit": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
-			"integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.6.tgz",
+			"integrity": "sha512-Ybn2I6fnfIGuCR+Faaz7YcvtBKxvoLV3Lebn1tM4o/IAJzmi9AWYIPWpyBfU8cC+JxAO57bk4+zdsTjJR+VTOw==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/helper-wasm-section": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1",
-				"@webassemblyjs/wasm-opt": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1",
-				"@webassemblyjs/wast-printer": "1.11.1"
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-buffer": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/helper-wasm-section": "1.11.6",
+				"@webassemblyjs/wasm-gen": "1.11.6",
+				"@webassemblyjs/wasm-opt": "1.11.6",
+				"@webassemblyjs/wasm-parser": "1.11.6",
+				"@webassemblyjs/wast-printer": "1.11.6"
 			}
 		},
 		"@webassemblyjs/wasm-gen": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
-			"integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.6.tgz",
+			"integrity": "sha512-3XOqkZP/y6B4F0PBAXvI1/bky7GryoogUtfwExeP/v7Nzwo1QLcq5oQmpKlftZLbT+ERUOAZVQjuNVak6UXjPA==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/ieee754": "1.11.1",
-				"@webassemblyjs/leb128": "1.11.1",
-				"@webassemblyjs/utf8": "1.11.1"
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/ieee754": "1.11.6",
+				"@webassemblyjs/leb128": "1.11.6",
+				"@webassemblyjs/utf8": "1.11.6"
 			}
 		},
 		"@webassemblyjs/wasm-opt": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
-			"integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.6.tgz",
+			"integrity": "sha512-cOrKuLRE7PCe6AsOVl7WasYf3wbSo4CeOk6PkrjS7g57MFfVUF9u6ysQBBODX0LdgSvQqRiGz3CXvIDKcPNy4g==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1"
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-buffer": "1.11.6",
+				"@webassemblyjs/wasm-gen": "1.11.6",
+				"@webassemblyjs/wasm-parser": "1.11.6"
 			}
 		},
 		"@webassemblyjs/wasm-parser": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
-			"integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.6.tgz",
+			"integrity": "sha512-6ZwPeGzMJM3Dqp3hCsLgESxBGtT/OeCvCZ4TA1JUPYgmhAx38tTPR9JaKy0S5H3evQpO/h2uWs2j6Yc/fjkpTQ==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-api-error": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/ieee754": "1.11.1",
-				"@webassemblyjs/leb128": "1.11.1",
-				"@webassemblyjs/utf8": "1.11.1"
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-api-error": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/ieee754": "1.11.6",
+				"@webassemblyjs/leb128": "1.11.6",
+				"@webassemblyjs/utf8": "1.11.6"
 			}
 		},
 		"@webassemblyjs/wast-printer": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
-			"integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.6.tgz",
+			"integrity": "sha512-JM7AhRcE+yW2GWYaKeHL5vt4xqee5N2WcezptmgyhNS+ScggqcT1OtXykhAb13Sn5Yas0j2uv9tHgrjwvzAP4A==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
+				"@webassemblyjs/ast": "1.11.6",
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webpack-cli/configtest": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
-			"integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
+			"integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
 			"dev": true,
 			"requires": {}
 		},
 		"@webpack-cli/info": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
-			"integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
+			"integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
 			"dev": true,
-			"requires": {
-				"envinfo": "^7.7.3"
-			}
+			"requires": {}
 		},
 		"@webpack-cli/serve": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
-			"integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
+			"integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
 			"dev": true,
 			"requires": {}
 		},
@@ -2547,9 +2459,9 @@
 			"dev": true
 		},
 		"acorn-import-assertions": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+			"integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
 			"dev": true,
 			"requires": {}
 		},
@@ -2581,16 +2493,6 @@
 				"color-convert": "^1.9.0"
 			}
 		},
-		"anymatch": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-			"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-			"dev": true,
-			"requires": {
-				"normalize-path": "^3.0.0",
-				"picomatch": "^2.0.4"
-			}
-		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2599,6 +2501,12 @@
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -2704,6 +2612,15 @@
 			"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
 			"dev": true
 		},
+		"combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
+			"requires": {
+				"delayed-stream": "~1.0.0"
+			}
+		},
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -2732,6 +2649,12 @@
 			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
 			"integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
 		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"dev": true
+		},
 		"diff": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
@@ -2745,9 +2668,9 @@
 			"dev": true
 		},
 		"enhanced-resolve": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
-			"integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
+			"version": "5.15.0",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
+			"integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.2.4",
@@ -2755,15 +2678,15 @@
 			}
 		},
 		"envinfo": {
-			"version": "7.8.1",
-			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
-			"integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.11.0.tgz",
+			"integrity": "sha512-G9/6xF1FPbIw0TtalAMaVPpiq2aDEuKLXM314jPVAO9r2fo2a4BLqMNkmRS7O/xPPZ+COAhGIz3ETvHEV3eUcg==",
 			"dev": true
 		},
 		"es-module-lexer": {
-			"version": "0.9.3",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
+			"integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==",
 			"dev": true
 		},
 		"escalade": {
@@ -2829,23 +2752,6 @@
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
 			"dev": true
 		},
-		"execa": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-			"dev": true,
-			"requires": {
-				"cross-spawn": "^7.0.3",
-				"get-stream": "^6.0.0",
-				"human-signals": "^2.1.0",
-				"is-stream": "^2.0.0",
-				"merge-stream": "^2.0.0",
-				"npm-run-path": "^4.0.1",
-				"onetime": "^5.1.2",
-				"signal-exit": "^3.0.3",
-				"strip-final-newline": "^2.0.0"
-			}
-		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2892,6 +2798,17 @@
 				"path-exists": "^4.0.0"
 			}
 		},
+		"form-data": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"dev": true,
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			}
+		},
 		"formdata-polyfill": {
 			"version": "4.0.10",
 			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -2906,10 +2823,10 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
 		},
-		"get-stream": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+		"function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
 			"dev": true
 		},
 		"glob": {
@@ -2944,11 +2861,14 @@
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
 		},
-		"human-signals": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-			"dev": true
+		"hasown": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+			"integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.2"
+			}
 		},
 		"import-local": {
 			"version": "3.0.3",
@@ -2977,10 +2897,19 @@
 			"dev": true
 		},
 		"interpret": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-			"integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+			"integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
 			"dev": true
+		},
+		"is-core-module": {
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+			"integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+			"dev": true,
+			"requires": {
+				"hasown": "^2.0.0"
+			}
 		},
 		"is-number": {
 			"version": "7.0.0",
@@ -2997,16 +2926,10 @@
 				"isobject": "^3.0.1"
 			}
 		},
-		"is-stream": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-			"dev": true
-		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
 		},
 		"isobject": {
@@ -3140,12 +3063,6 @@
 				"mime-db": "1.52.0"
 			}
 		},
-		"mimic-fn": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-			"dev": true
-		},
 		"minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3162,9 +3079,9 @@
 			"dev": true
 		},
 		"mkdirp": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+			"integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="
 		},
 		"neo-async": {
 			"version": "2.6.2",
@@ -3178,9 +3095,9 @@
 			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
 		},
 		"node-fetch": {
-			"version": "3.2.10",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
-			"integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
 			"requires": {
 				"data-uri-to-buffer": "^4.0.0",
 				"fetch-blob": "^3.1.4",
@@ -3193,21 +3110,6 @@
 			"integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
 			"dev": true
 		},
-		"normalize-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"dev": true
-		},
-		"npm-run-path": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-			"dev": true,
-			"requires": {
-				"path-key": "^3.0.0"
-			}
-		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3215,15 +3117,6 @@
 			"dev": true,
 			"requires": {
 				"wrappy": "1"
-			}
-		},
-		"onetime": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-			"dev": true,
-			"requires": {
-				"mimic-fn": "^2.1.0"
 			}
 		},
 		"p-limit": {
@@ -3280,12 +3173,6 @@
 			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
 			"dev": true
 		},
-		"picomatch": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-			"dev": true
-		},
 		"pkg-dir": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -3311,21 +3198,23 @@
 			}
 		},
 		"rechoir": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
-			"integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+			"integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
 			"dev": true,
 			"requires": {
-				"resolve": "^1.9.0"
+				"resolve": "^1.20.0"
 			}
 		},
 		"resolve": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-			"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+			"version": "1.22.8",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
 			"dev": true,
 			"requires": {
-				"path-parse": "^1.0.6"
+				"is-core-module": "^2.13.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
 			}
 		},
 		"resolve-cwd": {
@@ -3350,9 +3239,9 @@
 			"dev": true
 		},
 		"schema-utils": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-			"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+			"integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.8",
@@ -3363,7 +3252,8 @@
 		"semver": {
 			"version": "5.7.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"dev": true
 		},
 		"serialize-javascript": {
 			"version": "6.0.1",
@@ -3398,12 +3288,6 @@
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 			"dev": true
 		},
-		"signal-exit": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
-			"integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
-			"dev": true
-		},
 		"source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3426,12 +3310,6 @@
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},
-		"strip-final-newline": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-			"dev": true
-		},
 		"supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -3440,6 +3318,12 @@
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
+		},
+		"supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true
 		},
 		"tapable": {
 			"version": "2.2.1",
@@ -3482,15 +3366,16 @@
 			}
 		},
 		"ts-loader": {
-			"version": "9.4.2",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.4.2.tgz",
-			"integrity": "sha512-OmlC4WVmFv5I0PpaxYb+qGeGOdm5giHU7HwDDUjw59emP2UYMHy9fFSDcYgSNoH8sXcj4hGCSEhlDZ9ULeDraA==",
+			"version": "9.5.1",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.1.tgz",
+			"integrity": "sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.1.0",
 				"enhanced-resolve": "^5.0.0",
 				"micromatch": "^4.0.0",
-				"semver": "^7.3.4"
+				"semver": "^7.3.4",
+				"source-map": "^0.7.4"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -3542,6 +3427,12 @@
 						"lru-cache": "^6.0.0"
 					}
 				},
+				"source-map": {
+					"version": "0.7.4",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+					"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+					"dev": true
+				},
 				"supports-color": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3554,15 +3445,15 @@
 			}
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true
 		},
 		"tslint": {
-			"version": "5.20.1",
-			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-			"integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
+			"integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
@@ -3573,10 +3464,10 @@
 				"glob": "^7.1.1",
 				"js-yaml": "^3.13.1",
 				"minimatch": "^3.0.4",
-				"mkdirp": "^0.5.1",
+				"mkdirp": "^0.5.3",
 				"resolve": "^1.3.2",
 				"semver": "^5.3.0",
-				"tslib": "^1.8.0",
+				"tslib": "^1.13.0",
 				"tsutils": "^2.29.0"
 			},
 			"dependencies": {
@@ -3601,9 +3492,15 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.10",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+			"dev": true
+		},
+		"undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
 			"dev": true
 		},
 		"update-browserslist-db": {
@@ -3626,32 +3523,39 @@
 			}
 		},
 		"vscode-jsonrpc": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-			"integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg=="
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
+			"integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A=="
 		},
 		"vscode-languageclient": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-5.2.1.tgz",
-			"integrity": "sha512-7jrS/9WnV0ruqPamN1nE7qCxn0phkH5LjSgSp9h6qoJGoeAKzwKz/PF6M+iGA/aklx4GLZg1prddhEPQtuXI1Q==",
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-6.1.4.tgz",
+			"integrity": "sha512-EUOU+bJu6axmt0RFNo3nrglQLPXMfanbYViJee3Fbn2VuQoX0ZOI4uTYhSRvYLP2vfwTP/juV62P/mksCdTZMA==",
 			"requires": {
-				"semver": "^5.5.0",
-				"vscode-languageserver-protocol": "3.14.1"
+				"semver": "^6.3.0",
+				"vscode-languageserver-protocol": "3.15.3"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+					"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
+				}
 			}
 		},
 		"vscode-languageserver-protocol": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz",
-			"integrity": "sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==",
+			"version": "3.15.3",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz",
+			"integrity": "sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==",
 			"requires": {
-				"vscode-jsonrpc": "^4.0.0",
-				"vscode-languageserver-types": "3.14.0"
+				"vscode-jsonrpc": "^5.0.1",
+				"vscode-languageserver-types": "3.15.1"
 			}
 		},
 		"vscode-languageserver-types": {
-			"version": "3.14.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
-			"integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A=="
+			"version": "3.15.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
+			"integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
 		},
 		"watchpack": {
 			"version": "2.4.0",
@@ -3669,22 +3573,22 @@
 			"integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
 		},
 		"webpack": {
-			"version": "5.76.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.0.tgz",
-			"integrity": "sha512-l5sOdYBDunyf72HW8dF23rFtWq/7Zgvt/9ftMof71E/yUb1YLOBmTgA2K4vQthB3kotMrSj609txVE0dnr2fjA==",
+			"version": "5.89.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
+			"integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
 			"dev": true,
 			"requires": {
 				"@types/eslint-scope": "^3.7.3",
-				"@types/estree": "^0.0.51",
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/wasm-edit": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1",
+				"@types/estree": "^1.0.0",
+				"@webassemblyjs/ast": "^1.11.5",
+				"@webassemblyjs/wasm-edit": "^1.11.5",
+				"@webassemblyjs/wasm-parser": "^1.11.5",
 				"acorn": "^8.7.1",
-				"acorn-import-assertions": "^1.7.6",
+				"acorn-import-assertions": "^1.9.0",
 				"browserslist": "^4.14.5",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.10.0",
-				"es-module-lexer": "^0.9.0",
+				"enhanced-resolve": "^5.15.0",
+				"es-module-lexer": "^1.2.1",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
@@ -3693,37 +3597,38 @@
 				"loader-runner": "^4.2.0",
 				"mime-types": "^2.1.27",
 				"neo-async": "^2.6.2",
-				"schema-utils": "^3.1.0",
+				"schema-utils": "^3.2.0",
 				"tapable": "^2.1.1",
-				"terser-webpack-plugin": "^5.1.3",
+				"terser-webpack-plugin": "^5.3.7",
 				"watchpack": "^2.4.0",
 				"webpack-sources": "^3.2.3"
 			}
 		},
 		"webpack-cli": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
-			"integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
+			"integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
 			"dev": true,
 			"requires": {
 				"@discoveryjs/json-ext": "^0.5.0",
-				"@webpack-cli/configtest": "^1.1.0",
-				"@webpack-cli/info": "^1.4.0",
-				"@webpack-cli/serve": "^1.6.0",
+				"@webpack-cli/configtest": "^2.1.1",
+				"@webpack-cli/info": "^2.0.2",
+				"@webpack-cli/serve": "^2.0.5",
 				"colorette": "^2.0.14",
-				"commander": "^7.0.0",
-				"execa": "^5.0.0",
+				"commander": "^10.0.1",
+				"cross-spawn": "^7.0.3",
+				"envinfo": "^7.7.3",
 				"fastest-levenshtein": "^1.0.12",
 				"import-local": "^3.0.2",
-				"interpret": "^2.2.0",
-				"rechoir": "^0.7.0",
+				"interpret": "^3.1.1",
+				"rechoir": "^0.8.0",
 				"webpack-merge": "^5.7.3"
 			},
 			"dependencies": {
 				"commander": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-					"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+					"version": "10.0.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+					"integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
 					"dev": true
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dm-langclient",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"displayName": "DreamMaker Language Client",
 	"description": "Client for DreamMaker language server",
 	"publisher": "platymuus",
@@ -266,20 +266,20 @@
 		"test-compile": "tsc -p ./"
 	},
 	"dependencies": {
-		"mkdirp": "^1.0.4",
-		"node-fetch": "^3.2.10",
-		"vscode-languageclient": "^5.2.1"
+		"mkdirp": "^3.0.1",
+		"node-fetch": "^3.3.2",
+		"vscode-languageclient": "^6.1.4"
 	},
 	"devDependencies": {
-		"@types/mkdirp": "^1.0.2",
-		"@types/node": "^7.10.14",
-		"@types/node-fetch": "^1.6.9",
+		"@types/mkdirp": "^2.0.0",
+		"@types/node": "^20.11.0",
+		"@types/node-fetch": "^2.6.10",
 		"@types/vscode": "^1.30.0",
-		"@types/webpack": "^4.41.32",
-		"ts-loader": "^9.4.2",
-		"tslint": "^5.20.1",
-		"typescript": "^3.9.10",
-		"webpack": "^5.76.0",
-		"webpack-cli": "^4.9.1"
+		"@types/webpack": "^5.28.5",
+		"ts-loader": "^9.5.1",
+		"tslint": "^6.1.3",
+		"typescript": "^5.3.3",
+		"webpack": "^5.89.0",
+		"webpack-cli": "^5.1.4"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dm-langclient",
-	"version": "0.2.3",
+	"version": "0.2.2",
 	"displayName": "DreamMaker Language Client",
 	"description": "Client for DreamMaker language server",
 	"publisher": "platymuus",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { workspace, window, commands, ExtensionContext, StatusBarItem, StatusBar
 import * as vscode from 'vscode';
 import * as languageclient from 'vscode-languageclient';
 import fetch from 'node-fetch';
-import * as mkdirp from 'mkdirp';
+import { mkdirp } from 'mkdirp';
 import * as path from 'path';
 
 import { promisify, is_executable, md5_file, sleep } from './misc';
@@ -44,7 +44,7 @@ export async function activate(context: ExtensionContext) {
 		update_available = false;
 		try {
 			await lc.stop();
-		} catch(_) {}
+		} catch (_) { }
 		return start_language_client_catch(context);
 	}));
 	context.subscriptions.push(commands.registerCommand('dreammaker.toggleTicked', async () => {
@@ -359,7 +359,7 @@ async function update_copy(main_file: string, update_file: string) {
 		try {
 			await promisify(fs.rename)(update_file, main_file);
 			return;
-		} catch(e) {}
+		} catch (e) { }
 		// If this fails, it might be because the old process is still
 		// running in this window. Wait a bit and try again.
 		await sleep(250);
@@ -445,7 +445,7 @@ async function auto_update(context: ExtensionContext, platform: string, arch: st
 			if (hash) {
 				return;
 			}
-			// if hash is not set, fallthrough
+		// if hash is not set, fallthrough
 		case 404:  // Not found
 			return `Binaries are not available for ${arch}-${platform}.`;
 		case 410:  // Endpoint removed

--- a/src/objtree.ts
+++ b/src/objtree.ts
@@ -58,7 +58,7 @@ export class TreeProvider implements TreeDataProvider<ObjectTreeEntry> {
                     arguments: [uri.fragment],
                 };
             } else {
-                let uri = Uri.parse(element.location.uri).with({fragment: `${1 + element.location.range.start.line}`});
+                let uri = Uri.parse(element.location.uri).with({ fragment: `${1 + element.location.range.start.line}` });
                 item.command = {
                     title: "Go to Definition",
                     command: 'vscode.open',
@@ -128,8 +128,8 @@ export class TreeProvider implements TreeDataProvider<ObjectTreeEntry> {
 
 export class ObjectTreeFeature implements StaticFeature {
     fillClientCapabilities(capabilities: ClientCapabilities): void {
-        let experimental = (capabilities.experimental || (capabilities.experimental = {}));
-        let dreammaker = (experimental.dreammaker || (experimental.dreammaker = {}));
+        let experimental: { dreammaker?: any } = (capabilities.experimental || (capabilities.experimental = {}));
+        let dreammaker: any = (experimental.dreammaker || (experimental.dreammaker = {}));
         dreammaker.objectTree = true;
     }
 


### PR DESCRIPTION
`vsce` was moved to `@vscode/vsce`

Otherwise, just upgrading a bunch of npm packages. Didn't touch the @types/vscode so we still target the same minimum version.

needed to add the typehint to the objtree experimental object due to typescript complaining
tested by installing the vsix and using a lot of the features of the extension, and running the various npm jobs