### PR TITLE
Avoid highlighting `byond://?` as a comment

### DIFF
--- a/syntaxes/dm.tmLanguage.json
+++ b/syntaxes/dm.tmLanguage.json
@@ -478,7 +478,7 @@
                     "name": "comment.line.banner.dm"
                 },
                 {
-                    "begin": "//",
+                    "begin": "(?<!:)//",
                     "beginCaptures": {
                         "0": {
                             "name": "punctuation.definition.comment.dm"


### PR DESCRIPTION
This just slightly changes the comment regex to add a negative lookbehind to avoid marking `://?` in a string as a comment. I don't believe