### PR TITLE
Add -f to rm in vscode:prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -293,7 +293,7 @@
 		]
 	},
 	"scripts": {
-		"vscode:prepublish": "rm -r dist && webpack --mode production",
+		"vscode:prepublish": "rm -rf dist && webpack --mode production",
 		"build": "webpack --mode none",
 		"watch": "webpack --mode none --watch"
 	},


### PR DESCRIPTION
Currently the build fails if you don't already have a `dist` folder from a previous build because `rm` errors and `&&` requires the first command to succeed, adds the force flag so the error is suppressed